### PR TITLE
properly enable hidpi scaling

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,8 @@
 
 int main(int argc, char *argv[])
 {
+  QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+
   TabletApplication a(argc, argv);
 
   a.setWindowIcon(QIcon(":/MrWriter.png"));

--- a/src/tabletapplication.cpp
+++ b/src/tabletapplication.cpp
@@ -7,7 +7,6 @@
 
 TabletApplication::TabletApplication(int &argc, char **argv) : QApplication(argc, argv)
 {
-  QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
   QCoreApplication::setOrganizationName("unruhschuh");
   QCoreApplication::setOrganizationDomain("unruhschuh.com");
   QCoreApplication::setApplicationName("MrWriter");


### PR DESCRIPTION
hidpi scaling should be enabled before QCoreApplication object initialization, see Qt docs for AA_EnableHighDpiScaling